### PR TITLE
Update docs for new Vulkan modules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+WallensteinVR splits rendering and XR setup into small Zig modules.
+
+- `xr.zig` initializes OpenXR and manages the session.
+- `vulkan/context.zig` creates the Vulkan instance and selects a physical device.
+- `logicalDevice.zig` builds the logical device and exposes the graphics queue.
+- `vulkan/chef.zig` contains helpers like `createPhysicalDevice`.
+- `main.zig` wires the pieces together.
+
+This layout keeps the code base modular and easier to extend.

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,7 @@
                     <ul>
                         <li><a href="#" data-md="ci.md">Continuous Integration</a></li>
                         <li><a href="#" data-md="spellcheck.md">Spell Check</a></li>
+                        <li><a href="#" data-md="architecture.md">Architecture</a></li>
                         <li><a href="#" data-md="versions/1/changelog.md">Changelog</a></li>
                     </ul>
                 </li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,4 +16,5 @@ Use the version dropdown in the sidebar to view documentation for other releases
 - [Changelog](versions/1/changelog.md)
 - [Continuous Integration](ci.md)
 - [Spell Check](spellcheck.md)
+- [Architecture](architecture.md)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,6 +11,8 @@ and OpenXR for device support.
 - Modular `xr` and `vulkan` components
 - Physical device selection
 - Cross-platform surface support
+- Logical device initialization with queue access
+- Expanded XR helpers and cleaner Vulkan context
 
 Use the Usage Guide for build instructions.
 


### PR DESCRIPTION
## Summary

* **Docs-Only PR** – updates documentation to cover recent Vulkan and XR additions.
* Added `architecture.md` describing module layout.
* Updated features in `intro.md`.
* Linked the new page from `index.md` and navigation in `index.html`.

## Validation

1. Ran `codespell` on `/docs` – only existing typo in AGENTS file reported.
2. Attempted to install Zig and run `zig build`; package not available in environment.

## Checklist

* [x] I confirmed no source code outside `/docs` or `.github/workflows` was modified.
* [ ] Docs build cleanly without warnings.
* [ ] Workflows pass in a dry-run and on CI.

------
https://chatgpt.com/codex/tasks/task_e_6877d76f7094832b96bc31a25fc52ebc