### PR TITLE
docs: add API reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,44 @@
+# API Reference
+
+This page documents the main Zig modules and their exported functions.
+
+## xr.zig
+
+`Context` manages the OpenXR instance and session.
+
+- **init** – creates the instance, enables requested extensions and layers, and opens a session.
+- **deinit** – destroys the debug messenger, instance, and reference space.
+- **getVulkanExtensions** – returns the Vulkan instance extensions required by OpenXR.
+- **getXRFunction** – resolves an OpenXR function pointer safely.
+- **createDebugMessenger** – installs a debug messenger that logs XR warnings and errors.
+- **validateExtensions** – checks that requested OpenXR extensions exist.
+- **validateLayers** – checks that requested API layers exist.
+
+## vulkan/context.zig
+
+`Context` wraps the Vulkan instance and device.
+
+- **init** – creates the instance and selects a device.
+- **deinit** – destroys the instance when finished.
+- **createInstance** – internal helper that enables validation and required extensions.
+- **debugCallback** – receives messages from Vulkan validation layers.
+
+## vulkan/device.zig
+
+`Device` represents the Vulkan physical and logical device pair.
+
+- **init** – selects a GPU and creates a logical device with a graphics queue.
+- **deinit** – frees the logical device.
+- **selectPhysical** – chooses the first discrete GPU supporting geometry shaders.
+- **createLogicalDevice** – builds the logical device and retrieves its graphics queue.
+- **findQueueFamilies** – helper to locate the graphics queue family.
+
+## main.zig
+
+The `main` function wires everything together. It sets up required extensions and layers,
+initializes `xr.Context`, and will later create a Vulkan context.
+
+## c.zig
+
+`check` converts C return codes into Zig errors. `wrapXR` maps every OpenXR error code
+into a descriptive Zig error.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,12 @@ The `createViews()` function provides:
 - **Configuration Queries**: Automatic enumeration of view configuration properties
 - **Image Management**: Handles swapchain image enumeration and storage
 
+## Validation and Debugging
+
+- Validates requested OpenXR extensions and API layers before instance creation
+- Captures Vulkan warnings and errors using a debug messenger
+- Central `wrapXR` helper translates OpenXR error codes into readable Zig errors
+
 ## Vulkan Device Management
 
 The Vulkan device management is handled in two main components:

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,7 @@
                         <li><a href="#" data-md="ci.md">Continuous Integration</a></li>
                         <li><a href="#" data-md="spellcheck.md">Spell Check</a></li>
                         <li><a href="#" data-md="architecture.md">Architecture</a></li>
+                        <li><a href="#" data-md="api.md">API Reference</a></li>
                         <li><a href="#" data-md="versions/1/changelog.md">Changelog</a></li>
                     </ul>
                 </li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,5 @@ Use the version dropdown in the sidebar to view documentation for other releases
 - [Continuous Integration](ci.md)
 - [Spell Check](spellcheck.md)
 - [Architecture](architecture.md)
+- [API Reference](api.md)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -13,6 +13,8 @@ and OpenXR for device support.
 - Cross-platform surface support
 - Logical device initialization with queue access
 - Expanded XR helpers and cleaner Vulkan context
+- Validates OpenXR extensions and layers at startup
+- Vulkan debug messenger shows warnings and errors
 
 Use the Usage Guide for build instructions.
 


### PR DESCRIPTION
## Summary

* Added a new `API Reference` document describing public functions and structures.
* Updated navigation in `index.md` and `index.html` to link to the API page.

## Validation

- `codespell -q 3 docs/ -S docs/codex/AGENTS.md`
- `zig build` *(fails: missing Vulkan/OpenXR libraries)*

------
https://chatgpt.com/codex/tasks/task_e_6878344fae80832bbf47f53fc8bfd456