### PR TITLE
Docs: add dev environment and API examples

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,13 @@ This page documents the main Zig modules and their exported functions.
 - **validateExtensions** – checks that requested OpenXR extensions exist.
 - **validateLayers** – checks that requested API layers exist.
 
+### Example
+
+```zig
+var xr = try xr.Context.init(allocator, .{});
+defer xr.deinit();
+```
+
 ## vulkan/context.zig
 
 `Context` wraps the Vulkan instance and device.
@@ -22,6 +29,13 @@ This page documents the main Zig modules and their exported functions.
 - **deinit** – destroys the instance when finished.
 - **createInstance** – internal helper that enables validation and required extensions.
 - **debugCallback** – receives messages from Vulkan validation layers.
+
+### Example
+
+```zig
+var vk_ctx = try vulkan.Context.init(allocator);
+defer vk_ctx.deinit();
+```
 
 ## vulkan/device.zig
 
@@ -33,12 +47,33 @@ This page documents the main Zig modules and their exported functions.
 - **createLogicalDevice** – builds the logical device and retrieves its graphics queue.
 - **findQueueFamilies** – helper to locate the graphics queue family.
 
+### Example
+
+```zig
+var device = try vk.Device.init(allocator, instance);
+defer device.deinit();
+```
+
 ## main.zig
 
 The `main` function wires everything together. It sets up required extensions and layers,
 initializes `xr.Context`, and will later create a Vulkan context.
 
+### Example
+
+```zig
+pub fn main() !void {
+    var xr = try xr.Context.init(allocator, .{});
+    defer xr.deinit();
+    // Vulkan context initialization goes here
+}
+```
+
 ## c.zig
 
 `check` converts C return codes into Zig errors. `wrapXR` maps every OpenXR error code
 into a descriptive Zig error.
+
+```zig
+try c.check(c_some_function());
+```

--- a/docs/codex/AGENTS.md
+++ b/docs/codex/AGENTS.md
@@ -30,3 +30,7 @@ modify application source code**.
 * Active voice, present tense, ≤ 100‑character lines.
 * Use fenced code blocks and tables only when they improve clarity.
 * Prefer bulleted lists over long paragraphs.
+
+### Restrictions
+
+* Never modify the repository `README.md`.

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -1,0 +1,15 @@
+# Development Environment
+
+This project ships a Nix flake for a reproducible dev setup.
+
+```sh
+nix develop
+```
+
+The environment provides the Zig compiler, Vulkan SDK, and OpenXR headers. After entering the shell, build and test as usual:
+
+```sh
+zig build
+zig build test
+```
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
                     <ul>
                         <li><a href="#" data-md="intro.md">Introduction</a></li>
                         <li><a href="#" data-md="usage.md">Usage Guide</a></li>
+                        <li><a href="#" data-md="dev-env.md">Development Environment</a></li>
                     </ul>
                 </li>
                 <li class="category"><span>Other</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Use the version dropdown in the sidebar to view documentation for other releases
 
 - [Introduction](intro.md)
 - [Usage Guide](usage.md)
+- [Development Environment](dev-env.md)
 
 ### Other
 

--- a/docs/versions/1/changelog.md
+++ b/docs/versions/1/changelog.md
@@ -11,3 +11,7 @@
 - Introduced `logicalDevice.zig` to manage queue access
 - Reworked Vulkan and XR modules for clarity and surface support
 - Removed cached build artifacts from version control
+- Added Nix flake for reproducible development shells
+- Removed legacy C and C++ bindings in favor of pure Zig
+- Improved XR-Vulkan integration and debug utilities
+- Fixed several invalid pointer casts and cleanup warnings


### PR DESCRIPTION
## Summary

* **Docs-Only PR** – added a new `dev-env.md` describing the Nix flake development environment and linked it from the docs navigation.
* Expanded `docs/api.md` with short code examples for `xr.Context`, `vulkan.Context`, `vk.Device`, and `main` usage.
* Updated `docs/versions/1/changelog.md` with recent source changes such as removal of C/C++ wrappers and the new flake.
* Updated `docs/codex/AGENTS.md` to forbid modification of the repository `README.md`.

## Validation

- Ran `codespell docs/ -S docs/codex/AGENTS.md` to ensure documentation spelling correctness.


------
https://chatgpt.com/codex/tasks/task_e_6879772d80dc832bb114c4d756b2827e